### PR TITLE
Fix SyntaxError: f-string expression part cannot include a backslash

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1984,6 +1984,7 @@ class H3FaceTrackCrop:
         else:
             lockdesc = f"locked on at frame {lock_frame} of {B}"
 
+        render_line = f"rendering: {K} of {B} frames  [{drop_note}]\n" if drop_note else ""
         report = (
             f"subject: {'from face_pick, one per shot' if forced else _sel_desc}"
             f"{'' if (ranking_picks or forced) else ' (ignored - identity_reference decides)'}, "
@@ -1996,7 +1997,7 @@ class H3FaceTrackCrop:
             f"tracking: {n_cont} by continuity, {n_conflict} ambiguous "
             f"({n_ident} resolved by face identity)\n"
             f"{identline}"
-            f"{f'rendering: {K} of {B} frames  [{drop_note}]\n' if drop_note else ''}"
+            f"{render_line}"
             f"frames={B}  face={found} ({found/B*100:.0f}%)  "
             f"body-fallback={int(via_body.sum())}  interpolated={B-int(known.sum())}\n"
             f"face height  min={sz.min():.0f}px  mean={sz.mean():.0f}px  max={sz.max():.0f}px\n"


### PR DESCRIPTION
`nodes.py` fails to import on Python < 3.12 (i.e. most portable/embedded ComfyUI builds, which ship 3.10 or 3.11) with:

    SyntaxError: f-string expression part cannot include a backslash

Cause: inside `H3FaceTrackCrop.run`, the `report` string contains a nested f-string whose expression part includes `\n`:

    f"{f'rendering: {K} of {B} frames  [{drop_note}]\n' if drop_note else ''}"

Backslashes inside the `{...}` part of an f-string (even hidden inside a nested f-string literal) are illegal before PEP 701 (Python 3.12), which made the whole node pack fail to load on any older interpreter.

Fix: hoist the nested f-string out into a plain variable before use.