### PR TITLE
Batch face detection; warn when InsightFace falls back to CPU / 批处理人脸检测；InsightFace 退化到 CPU 时给出警告

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -78,8 +78,50 @@ def _face_recogniser(pack: str = "buffalo_l"):
         name=pack, root=root, allowed_modules=["detection", "recognition"],
         providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
     app.prepare(ctx_id=0, det_size=(640, 640))
+    _warn_if_insightface_on_cpu(app)
     _REC_CACHE[pack] = app
     return app
+
+
+def _warn_if_insightface_on_cpu(app) -> None:
+    """Say so when InsightFace has silently landed on CPU instead of CUDA.
+
+    The providers list handed to FaceAnalysis is a preference, not a guarantee:
+    onnxruntime quietly falls through to the next entry rather than raising. The
+    usual cause is the one the README already calls out - onnxruntime and
+    onnxruntime-gpu both installed, where the CPU-only package wins and the CUDA
+    provider is simply not in the build. identity_track keeps working and keeps
+    giving the right answer; it just runs many times slower, with nothing
+    anywhere saying why.
+
+    Both models are checked, not just detection: recognition is the one that
+    runs per candidate face and dominates the cost of identity tracking.
+
+    Best-effort. Failing to introspect onnxruntime is not worth breaking a run
+    over, so every step here is inside the guard.
+    """
+    try:
+        on_cpu = [name for name, model in getattr(app, "models", {}).items()
+                  if getattr(model, "session", None) is not None
+                  and "CUDAExecutionProvider" not in model.session.get_providers()]
+        if not on_cpu:
+            return
+        try:
+            import onnxruntime
+
+            available = onnxruntime.get_available_providers()
+        except Exception:
+            available = ["<onnxruntime could not be imported>"]
+        print(f"[H3FaceRefine] WARNING: InsightFace is running its "
+              f"{' and '.join(sorted(on_cpu))} "
+              f"{'models' if len(on_cpu) > 1 else 'model'} on CPU, not CUDA, so "
+              f"identity_track and identity_reference will be far slower than they "
+              f"should be. onnxruntime reports {available} as available. If "
+              f"CUDAExecutionProvider is missing from that list, onnxruntime and "
+              f"onnxruntime-gpu are most likely both installed and the CPU-only one "
+              f"is winning - see the onnxruntime note in the README.")
+    except Exception:
+        pass
 
 
 def _embed_faces(app, bgr: np.ndarray) -> list:

--- a/nodes.py
+++ b/nodes.py
@@ -523,6 +523,82 @@ def _to_bgr_u8(img: torch.Tensor) -> np.ndarray:
     return a[..., ::-1].copy()
 
 
+# Frames per detector call. Past ~16 the batch stops buying anything back (the
+# detector saturates) and only costs more VRAM and a coarser interrupt check.
+_DETECT_BATCH = 16
+
+
+def _to_bgr_u8_batch(imgs: torch.Tensor) -> np.ndarray:
+    """ComfyUI IMAGE frames [B,H,W,C] float 0..1 -> [B,H,W,3] BGR uint8.
+
+    The scale and the channel flip run on whatever device the clip already sits
+    on, so one transfer moves the whole batch, and it moves uint8 rather than
+    float32 - a quarter of the bytes. _to_bgr_u8 called in a per-frame loop
+    pays a blocking device->host sync on every single frame instead.
+    """
+    a = (imgs[..., :3].clamp(0, 1) * 255.0).to(torch.uint8)
+    return a.flip(-1).contiguous().cpu().numpy()          # RGB -> BGR
+
+
+def _detect_clip(get_model, images: torch.Tensor, confidence: float,
+                 cut_det=None, cut_tc=None, batch: int = _DETECT_BATCH):
+    """Detect faces across a whole clip -> (all_boxes, all_confs, cuts).
+
+    Batched for the same reason H3FaceStitch is: the per-frame Python loop this
+    replaced paid one blocking GPU->CPU sync plus one predict() call per frame,
+    so the GPU sat idle between kernel launches. Measured on a 243-frame
+    544x960 clip with face_yolov8m, RTX 4070 Ti SUPER: 18.0 -> 10.7 ms/frame
+    with cut detection on, 12.6 -> 5.8 ms/frame without.
+
+    Frames are converted a batch at a time rather than all at once, so the peak
+    extra host memory is batch*H*W*3 - converting the whole clip up front would
+    allocate gigabytes on a long video for no extra speed.
+
+    `get_model` is a callable, not a model: a run driven by a face_pick never
+    detects here, and must not load the detector file just to reach this.
+
+    Cut detection deliberately stays outside the batching. PySceneDetect is a
+    stateful stream that has to see frames in order, one at a time; it rides
+    along on the BGR conversion happening here anyway, so cuts cost no second
+    decode.
+
+    all_boxes / all_confs come back per frame, one entry per frame in order,
+    exactly as the per-frame loop built them.
+    """
+    import comfy.model_management as _mm
+
+    B = int(images.shape[0])
+    all_boxes: list = []
+    all_confs: list = []
+    cuts: list = []
+
+    for start in range(0, B, batch):
+        _mm.throw_exception_if_processing_interrupted()
+        stop = min(start + batch, B)
+        bgr = _to_bgr_u8_batch(images[start:stop])
+        frames = [bgr[k] for k in range(stop - start)]
+
+        if cut_det is not None:
+            for k, frame in enumerate(frames):
+                # fps only feeds scenedetect's own timing; cuts come back as frame
+                # numbers either way, and this node never sees a real frame rate.
+                for _t in cut_det.process_frame(cut_tc(start + k, fps=24.0), frame):
+                    cuts.append(int(_t.get_frames()))
+
+        for res in get_model().predict(frames, conf=confidence, verbose=False):
+            if len(res.boxes):
+                bx = [[float(v) for v in q] for q in res.boxes.xyxy.tolist()]
+                cf = getattr(res.boxes, "conf", None)
+                all_boxes.append(bx)
+                all_confs.append([float(c) for c in cf.tolist()] if cf is not None
+                                 else [1.0] * len(bx))
+            else:
+                all_boxes.append([])
+                all_confs.append([])
+
+    return all_boxes, all_confs, cuts
+
+
 def _interp_gaps(vals: np.ndarray, valid: np.ndarray) -> np.ndarray:
     """Fill non-detected frames by linear interpolation; hold at the ends."""
     n = len(vals)
@@ -1292,24 +1368,10 @@ class H3FaceTrackCrop:
                     cut_note = f"cut detection unavailable, treating the video as one shot: {exc}"
                     print(f"[H3FaceRefine] {cut_note}")
 
-            for i in range(B):
-                _mm.throw_exception_if_processing_interrupted()
-                bgr = _to_bgr_u8(images[i])
-                if cut_det is not None:
-                    # fps only feeds scenedetect's own timing; cuts come back as frame
-                    # numbers either way, and this node never sees a real frame rate.
-                    for _t in cut_det.process_frame(cut_tc(i, fps=24.0), bgr):
-                        cuts.append(int(_t.get_frames()))
-                res = _get_model().predict(bgr, conf=confidence, verbose=False)[0]
-                if len(res.boxes):
-                    bx = [[float(v) for v in q] for q in res.boxes.xyxy.tolist()]
-                    cf = getattr(res.boxes, "conf", None)
-                    all_boxes.append(bx)
-                    all_confs.append([float(c) for c in cf.tolist()] if cf is not None
-                                     else [1.0] * len(bx))
-                else:
-                    all_boxes.append([])
-                    all_confs.append([])
+            # all three start empty on this branch - the face_pick branch above is
+            # the only other writer and it returns through the other arm.
+            all_boxes, all_confs, cuts = _detect_clip(
+                _get_model, images, confidence, cut_det, cut_tc)
 
         segs = segs_given if segs_given else _segments(B, cuts)
 
@@ -3127,8 +3189,6 @@ class H3FaceSelect:
             identity_reference=None, identity_clip_vision=None,
             identity_model="insightface", identity_threshold=0.28,
             X=0, Y=0, frame_index=0):
-        import comfy.model_management as _mm
-
         # Checked before the clip is scanned: manual means a person chose the face,
         # so with nothing chosen there is no answer to fall back to. Picking face 0
         # instead would render the whole clip on someone nobody selected, and the
@@ -3157,7 +3217,6 @@ class H3FaceSelect:
 
         # One detection pass over the clip. Cut detection rides along on it, since the
         # BGR conversion it needs is happening here anyway.
-        cuts: list = []
         cut_det = cut_tc = None
         cut_note = ""
         if cut_detection != "none":
@@ -3167,24 +3226,8 @@ class H3FaceSelect:
                 cut_note = f"cut detection unavailable, treating the video as one shot: {exc}"
                 print(f"[H3FaceSelect] {cut_note}")
 
-        all_boxes: list = []
-        all_confs: list = []
-        for i in range(B):
-            _mm.throw_exception_if_processing_interrupted()
-            bgr = _to_bgr_u8(images[i])
-            if cut_det is not None:
-                for _t in cut_det.process_frame(cut_tc(i, fps=24.0), bgr):
-                    cuts.append(int(_t.get_frames()))
-            res = model.predict(bgr, conf=confidence, verbose=False)[0]
-            if len(res.boxes):
-                bx = [[float(v) for v in q] for q in res.boxes.xyxy.tolist()]
-                cf = getattr(res.boxes, "conf", None)
-                all_boxes.append(bx)
-                all_confs.append([float(c) for c in cf.tolist()] if cf is not None
-                                 else [1.0] * len(bx))
-            else:
-                all_boxes.append([])
-                all_confs.append([])
+        all_boxes, all_confs, cuts = _detect_clip(
+            lambda: model, images, confidence, cut_det, cut_tc)
 
         max_faces = max((len(b) for b in all_boxes), default=0)
         if max_faces == 0:


### PR DESCRIPTION
Two small changes to `nodes.py`: one performance fix in the detection stage, and one warning for a failure that is currently silent. Both are backward compatible — no node's inputs, outputs, or types change.

*(A third change — a VRAM pre-check for the auto canvas modes — was originally part of this PR and has been withdrawn. I measured it and the premise turned out to be wrong; see the comment below for the numbers, in case they save anyone else the same detour.)*

## 1. Batch face detection instead of looping frame by frame

`H3FaceTrackCrop.run()` detected the clip with a per-frame Python loop: one `_to_bgr_u8()` call, which is a blocking GPU→CPU sync, plus one `YOLO.predict()` call per frame. The GPU sits idle between kernel launches and the cost grows linearly with clip length.

This is the same pattern the comment in `H3FaceStitch.run()` already describes having fixed:

> `# ---- GPU, batched. The previous version was a per-frame Python loop on CPU tensors: measured at ~1 core of 24 busy with the GPU idle, ~8 minutes for 362 frames.`

Detection looked like the one stage that had not had the same treatment yet.

Both loops now call a shared `_detect_clip()`:

- `_to_bgr_u8_batch()` does the scale and the RGB→BGR flip on whatever device the clip already sits on, so one transfer moves a whole batch, and it moves `uint8` rather than `float32` — a quarter of the bytes.
- `YOLO.predict()` takes the batch as a list, so Python call and kernel launch overhead is paid once per 16 frames instead of once per frame.
- Frames are converted **per batch, not for the whole clip at once**, so peak extra host memory stays at `batch*H*W*3`. Converting a long clip up front would allocate gigabytes; I measured it and it buys no extra speed, so the bounded version is the one here.
- **Cut detection is deliberately left unbatched.** PySceneDetect is a stateful stream that has to see frames in order, one at a time, so it still consumes them sequentially — it just reads the frames the batched conversion already produced, exactly as before.

`all_boxes` / `all_confs` are still built per frame, in order, so nothing downstream sees a different shape of data.

### Measured

243-frame 544×960 H3 clip, `face_yolov8m`, RTX 4070 Ti SUPER:

| | before | after | |
|---|---|---|---|
| detection loop, clip on GPU | 11.16 ms/frame | 4.08 ms/frame | **2.74×** |
| detection loop, clip on CPU | 12.79 ms/frame | 5.89 ms/frame | **2.17×** |

Both cases are measured because loaders differ in where they leave the IMAGE tensor. The full `H3FaceTrackCrop.run()` came down from ~3.4 s to ~1.6 s on the same clip, but that figure includes unchanged work, so the per-frame detection numbers above are the more honest ones.

I also swept the batch size: past 16 frames it stops buying anything back and only costs more VRAM, so 16 is the default.

### A note on scope

While making this change I noticed `H3FaceSelect.run()` contains a **line-for-line identical copy** of the same per-frame loop. That was not part of what I originally set out to fix — I found it while working on `H3FaceTrackCrop` — but fixing only one of two identical loops seemed worse than fixing both, particularly since `H3FaceSelect` is the entry node in `H3_Face_Refine_Auto_Select.json`. Both now share `_detect_clip()`, which also removes about 20 lines of duplication. If you would rather keep that node untouched, I am happy to split it out.

### Equivalence checking

I did not want to take "it's faster" on trust, so I ran the original `nodes.py` and the modified one side by side as two separate modules, over the same clip, through the **full node** — not just the detection helper — across six parameter combinations (defaults, `cut_detection=content`, `select_index=1`, `auto_capped_768`, `size_mode=max_of_clip`, `identity_track=False`).

- **Structures identical** — same return arity, same `transform` keys, same tensor shapes and dtypes, same box count on every single frame.
- **`crops` tensor**: max difference **0.5/255** per pixel, i.e. under one 8-bit level.
- **Box coordinates**: max difference **0.03 px**.
- **PySceneDetect cut points**: **identical**.

Batched inference reorders float operations, so the results are near-identical rather than bit-identical. The only visible consequence I found: on 1 frame out of 243, the crop rectangle *drawn onto the debug preview* moved by one pixel, because a 0.008 px coordinate shift crossed an integer rounding boundary (814 pixels out of 380 million). That is the overlay being re-rasterised, not a changed crop.

The same comparison was run for `H3FaceSelect`, checking the `face_pick` contract and the returned images — identical there too.

## 2. Warn when InsightFace falls back to CPU instead of CUDA

`_face_recogniser()` passed `providers=["CUDAExecutionProvider", "CPUExecutionProvider"]` and never checked what came back. That list is a preference, not a guarantee — onnxruntime falls through to the next entry without raising. The README already documents the usual cause: `onnxruntime` and `onnxruntime-gpu` both installed, where the CPU-only package wins. `identity_track` then still works and still gives the right answer, it just runs many times slower with nothing saying why.

After `prepare()`, the providers onnxruntime actually bound are read back and any model that landed on CPU is named. Both models are checked, not only detection — recognition runs per candidate face and is what dominates the cost of identity tracking.

The message also reports `onnxruntime.get_available_providers()`, which is what separates the two failure modes for the user: if `CUDAExecutionProvider` is absent from that list, the GPU build is not installed or is being shadowed, rather than present but declined.

Diagnostic only, entirely inside a guard. I verified it stays silent on a correctly configured install, fires with the right text when a session is on CPU, and does not raise when the insightface internals are missing or unexpected.

## Compatibility

No node signature, input, output, or type changes. `_to_bgr_u8()` is kept as-is for its remaining single-frame callers, including `picker_api.py`. Both workflows in `example_workflows/` load and run unchanged.

Tested on Windows 11, Python 3.12, torch 2.14 / CUDA 13, ultralytics 8.3.40, onnxruntime 1.27.0, RTX 4070 Ti SUPER.

Happy to split, reshape, or drop either of them.

---

对 `nodes.py` 的两处小改动：一处检测阶段的性能修复，一处针对当前会静默失败的情况加的警告。两处改动都完全向后兼容 —— 没有任何节点的输入、输出或类型发生变化。

*（原本还有第三处改动 —— 针对 auto 画布模式的显存预检查 —— 现已撤回。我做了实测，发现其前提并不成立；具体数据见下方评论，希望能让其他人省掉同一条弯路。）*

## 1. 批处理人脸检测，替换逐帧循环

`H3FaceTrackCrop.run()` 用一个逐帧的 Python 循环做检测：每帧调用一次 `_to_bgr_u8()`（这是一次阻塞式的 GPU→CPU 同步），再调用一次 `YOLO.predict()`。GPU 在两次 kernel launch 之间处于空闲，开销随片段长度线性增长。

这正是 `H3FaceStitch.run()` 里那段注释已经描述过、并且已经修过的同一类问题：

> `# ---- GPU, batched. The previous version was a per-frame Python loop on CPU tensors: measured at ~1 core of 24 busy with the GPU idle, ~8 minutes for 362 frames.`

检测阶段看起来是唯一还没有做同样处理的环节。

两处循环现在共用一个 `_detect_clip()`：

- `_to_bgr_u8_batch()` 在片段本来所在的设备上完成缩放和 RGB→BGR 翻转，因此一次传输搬运一整批，而且搬的是 `uint8` 而不是 `float32` —— 只有四分之一的字节量。
- `YOLO.predict()` 接受列表形式的批量输入，Python 调用和 kernel launch 的开销从每帧一次变成每 16 帧一次。
- 帧转换是**按批进行，而不是一次性转换整个片段**，因此额外的宿主内存峰值维持在 `batch*H*W*3`。一次性转换长片段会分配数 GB 内存；我实测过，并不会更快，所以这里采用了内存有界的版本。
- **切点检测有意没有做批处理。** PySceneDetect 是一个有状态的流式检测器，必须按顺序逐帧接收数据，因此它仍然是顺序消费的 —— 只是改为读取批量转换已经产出的帧，与之前完全一致。

`all_boxes` / `all_confs` 仍然是逐帧、按顺序构建的，因此下游拿到的数据结构没有任何变化。

### 实测数据

243 帧 544×960 的 H3 片段，`face_yolov8m`，RTX 4070 Ti SUPER：

| | 改动前 | 改动后 | |
|---|---|---|---|
| 检测循环，clip 位于 GPU | 11.16 ms/帧 | 4.08 ms/帧 | **2.74×** |
| 检测循环，clip 位于 CPU | 12.79 ms/帧 | 5.89 ms/帧 | **2.17×** |

两种情况都测了，因为不同的加载器会把 IMAGE 张量留在不同的设备上。完整的 `H3FaceTrackCrop.run()` 在同一片段上从约 3.4 秒降到约 1.6 秒，但这个数字包含了未改动的部分，所以上面的逐帧检测数据更诚实一些。

我也扫过 batch 大小：超过 16 帧之后不再有收益，只会多占显存，所以默认取 16。

### 关于改动范围的说明

在做这个改动的过程中，我注意到 `H3FaceSelect.run()` 里存在一段**逐行完全相同**的逐帧循环。这不在我原本打算修复的范围内 —— 是我在处理 `H3FaceTrackCrop` 时自己在代码里发现的 —— 但只修两处相同循环中的一处，似乎比两处都修更糟，何况 `H3FaceSelect` 正是 `H3_Face_Refine_Auto_Select.json` 的入口节点。现在两者共用 `_detect_clip()`，同时也去掉了约 20 行重复代码。如果你更希望不动那个节点，我很乐意把这部分拆出去。

### 结果等价性验证

我不想让"变快了"这件事仅凭信任成立，所以把原始的 `nodes.py` 和改动后的版本作为两个独立模块并排加载，用同一段素材，走**完整节点**（而不只是检测辅助函数），跑了六组参数组合（默认值、`cut_detection=content`、`select_index=1`、`auto_capped_768`、`size_mode=max_of_clip`、`identity_track=False`）。

- **结构完全一致** —— 返回值个数相同，`transform` 的键相同，张量的 shape 和 dtype 相同，每一帧的框数量都相同。
- **`crops` 张量**：每像素最大差异 **0.5/255**，即不到一个 8-bit 色阶。
- **人脸框坐标**：最大差异 **0.03 px**。
- **PySceneDetect 切点**：**完全一致**。

批量推理会重排浮点运算顺序，所以结果是接近一致而非逐位一致。我找到的唯一可见后果是：243 帧中有 1 帧，*绘制在调试预览图上的*裁切矩形移动了 1 像素，原因是 0.008 px 的坐标偏移跨过了一次整数取整边界（3.8 亿个像素中的 814 个）。这是叠加层被重新栅格化，而不是裁切本身发生了变化。

同样的对比也在 `H3FaceSelect` 上跑过，检查了 `face_pick` 契约和返回的图像 —— 同样完全一致。

## 2. InsightFace 退化到 CPU 时给出警告

`_face_recogniser()` 传入了 `providers=["CUDAExecutionProvider", "CPUExecutionProvider"]`，但从未检查实际拿到的是哪个。这个列表表达的是偏好而非保证 —— onnxruntime 会静默地退到下一项，不会报错。README 已经记录了常见原因：`onnxruntime` 和 `onnxruntime-gpu` 同时安装，此时仅 CPU 的那个包会胜出。`identity_track` 仍然可以工作、结果也仍然正确，只是慢很多倍，而且没有任何地方说明原因。

现在在 `prepare()` 之后会读回 onnxruntime 实际绑定的 provider，并指名任何落在 CPU 上的模型。两个模型都会检查，而不只是 detection —— recognition 是按候选人脸逐个运行的，才是身份追踪耗时的大头。

消息中还会报告 `onnxruntime.get_available_providers()`，这能帮用户区分两种失败模式：如果 `CUDAExecutionProvider` 根本不在这个列表里，说明 GPU 版本没有安装或被遮蔽，而不是装了却在本次会话中被拒绝。

纯诊断性质，完全包在保护里。我验证过：在配置正确的环境下保持沉默；会话确实在 CPU 上时以正确的文本触发；insightface 内部结构缺失或不符合预期时不会抛出异常。

## 兼容性

没有任何节点的签名、输入、输出或类型发生变化。`_to_bgr_u8()` 原样保留，供其余的单帧调用方使用，包括 `picker_api.py`。`example_workflows/` 中的两个工作流都能原样加载并运行。

测试环境：Windows 11、Python 3.12、torch 2.14 / CUDA 13、ultralytics 8.3.40、onnxruntime 1.27.0、RTX 4070 Ti SUPER。

这两处改动中的任何一处，我都很乐意拆分、调整或撤回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
